### PR TITLE
Add ability to add private keys (PEM format) to truststore

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -5,7 +5,11 @@ terraform {
       version = "~> 3.1.0"
     }
     jks = {
-      source  = "hashicorp.com/outfox/jks-trust-store"
+      # Locally compiled provider
+      #source  = "hashicorp.com/outfox/jks-trust-store"
+
+      # Terraform forge hosted provider
+      source  = "outfoxx/jks-trust-store"
       version = "~> 0.1"
     }
   }
@@ -29,7 +33,7 @@ resource "tls_self_signed_cert" "ca" {
   early_renewal_hours   = 3
 
   is_ca_certificate = true
-  allowed_uses      = [
+  allowed_uses = [
     "cert_signing",
     "crl_signing",
   ]

--- a/jks-trust-store/resource_trust_store.go
+++ b/jks-trust-store/resource_trust_store.go
@@ -73,7 +73,7 @@ func resourceTrustStoreCreate(_ context.Context, d *schema.ResourceData, _ inter
 				break
 			} else if block == nil {
 				diags = append(diags, diag.Errorf("chain %d, certificate %d: failed to load PEM", chainIdx, certIdx)...)
-			} else if block.Type != "CERTIFICATE" {
+			} else if (block.Type != "CERTIFICATE") && (block.Type != "EC PRIVATE KEY") {
 				diags = append(diags, diag.Errorf("chain %d, certificate %d: expected CERTIFICATE but found %q", chainIdx, certIdx, block.Type)...)
 			}
 


### PR DESCRIPTION
I have a use case where I need the following in my trust store:

CA cert
self signed cert
self signed cert's private key (in PEM format)

This small PR adds the ability to store private keys

```
resource "tls_private_key" "es_key" {
  algorithm = "ECDSA"
}

resource "jks_trust_store" "ca" {
  certificates = [
    tls_private_key.es_key.private_key_pem,
  ]
  password = "none"
}
```